### PR TITLE
feat: add supabase auth bootstrap and cors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ This project provides a serverless endpoint your Webflow site can call to verify
    - In Vercel Project Settings → *Environment Variables*, add:
      - `OPENAI_API_KEY` = your OpenAI API key
      - (optional) `RENTALGUARD_MODEL` = `gpt-4.1-mini`
+     - `SUPABASE_URL` = your Supabase project URL
+     - `SUPABASE_SERVICE_ROLE_KEY` = your Supabase service role key (server only)
+     - (optional) `CORS_ORIGIN` = allowed origin for CORS
+     - `NEXT_PUBLIC_SUPABASE_URL` = same as `SUPABASE_URL` but safe for the browser
+     - `NEXT_PUBLIC_SUPABASE_ANON_KEY` = your Supabase anon key
 
 3. **Deploy**
    - After deploy, your endpoint will be:

--- a/api/_cors.js
+++ b/api/_cors.js
@@ -1,4 +1,4 @@
-export function setCORS(res, origin = process.env.ALLOWED_ORIGIN || '*') {
+export function setCORS(res, origin = process.env.CORS_ORIGIN || '*') {
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Vary', 'Origin');
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');

--- a/api/verify.js
+++ b/api/verify.js
@@ -1,16 +1,12 @@
 // /api/verify — Vercel serverless function (Node 20)
 import OpenAI from "openai";
+import { setCORS, handlePreflight } from "./_cors.js";
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-function cors(res) {
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-}
-
 export default async function handler(req, res) {
-  cors(res);
-  if (req.method === "OPTIONS") return res.status(200).end();
+  if (handlePreflight(req, res)) return;
+  setCORS(res);
+
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   try {

--- a/ht-auth.js
+++ b/ht-auth.js
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  { auth: { persistSession: true, detectSessionInUrl: true } }
+);
+
+async function getUser() {
+  const { data: u1 } = await supabase.auth.getUser();
+  if (u1?.user) return u1.user;
+  const { data: s } = await supabase.auth.getSession();
+  return s?.session?.user ?? null;
+}
+
+async function authHeader() {
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+const htAuth = { supabase, getUser, authHeader };
+
+if (typeof window !== 'undefined') {
+  window.htAuth = htAuth;
+}
+
+export default htAuth;


### PR DESCRIPTION
## Summary
- add reusable Supabase auth helper for browser clients
- configure CORS via `CORS_ORIGIN` and reuse across API routes
- document Supabase environment variables

## Testing
- `npm test` (fails: Missing script "test")
- `node --test api/verify.test.js` (fails: Cannot find package 'openai')
- `npm install` (fails: 403 Forbidden fetching @supabase/supabase-js)


------
https://chatgpt.com/codex/tasks/task_e_68b9f3617760832eb23969867eac01c6